### PR TITLE
POD updates for CGI::Ex::Validate

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+3.01
+    2015-03-31
+        * META information now includes GitHub repo.
+        * CGI::Ex::Validate POD describes match => ... construct in more detail.
+
 3.00
     2013-09-26
         * Documentation overhaul

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@
     2015-03-31
         * META information now includes GitHub repo.
         * CGI::Ex::Validate POD describes match => ... construct in more detail.
+        * Fixed POD bug in 'required' section, and provided another
+          'validate_if' example.
 
 3.00
     2013-09-26

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,27 @@ WriteMakefile(
     realclean         => {
         FILES        => '*~',
     },
-    );
+    META_MERGE => {
+        'meta-spec'   => { version => 2 },
+        resources     => {
+            bugtracker => {
+                web => 'https://rt.cpan.org/Public/Dist/Display.html?Name=CGI-Ex',
+            },
+            repository => {
+                type  => 'git',
+                url   => 'https://github.com/rhandom/perl-cgi-ex.git',
+                web   => 'https://github.com/rhandom/perl-cgi-ex',
+            },
+        },
+        prereqs => {
+            runtime => {
+                requires    => {
+                    'Template::Alloy' => '1.020',
+                },
+            },
+        },
+    },
+);
 
 package MY;
 

--- a/lib/CGI/Ex.pm
+++ b/lib/CGI/Ex.pm
@@ -13,7 +13,7 @@ CGI::Ex - CGI utility suite - makes powerful application writing fun and easy
 use strict;
 use warnings;
 
-our $VERSION = '3.00';
+our $VERSION = '3.01';
 our $PREFERRED_CGI_MODULE ||= 'CGI';
 our $DEBUG_LOCATION_BOUNCE;
 our $GLOBAL_CGIX;

--- a/lib/CGI/Ex/Validate.pod
+++ b/lib/CGI/Ex/Validate.pod
@@ -483,6 +483,26 @@ be concatenated with ||.  Available in JS.
         match_2 => '!m/^0\./ || !m/^192\./',
     }
 
+Because the regex is string-evaled into existence within a different package,
+variable interpolation can be problematic.  A demonstration is clearer than an
+explanation here:
+
+    use Regexp::Common qw(net);
+    {
+        match => 'm/^$RE{net}{IPv4}$/', # Don't do this
+        ...,
+    }
+
+This fails because the C<%RE> hash hasn't been imported into the same package
+into which this regex will be evaled.  If such a construct is needed, it's 
+probably preferable to use C<custom> instead:
+
+    use Regexp::Common qw(net);
+    {
+        custom => sub { my($key,$val) = @_; return $val =~ m/^$RE{net}{IPv4}$/; },
+        ...,
+    }
+
 =item C<max_in_set> and C<min_in_set>
 
 Somewhat like min_values and max_values except that you specify the

--- a/lib/CGI/Ex/Validate.pod
+++ b/lib/CGI/Ex/Validate.pod
@@ -541,9 +541,10 @@ to allow more than one item by any given name).
 Requires the form field to have some value.  If the field is not present,
 no other checks will be run and an error will be given.
 
-It has been common for code to try C<required => 0> which essentially has
-no effect - instead use C<validate_if => 'fieldname', required => 1>.  This
-results in the fieldname only being required if the fieldname is present.
+It has been a common mistake for code to try C<< required => 0 >> which 
+essentially has no effect - instead use 
+C<< validate_if => 'fieldname', required => 1 >>.  This results in the 
+fieldname only being required if the fieldname is present.
 
 =item C<required_if>
 
@@ -688,8 +689,15 @@ if the conditions are met.  Works in JS.
         equals      => '$1_pass',
         required    => 1,
     }
-
     # will validate foo_pass only if foo_user was present.
+
+    myfield => {
+        validate_if => 'myfield',
+        desc        => 'A field that is not required, but that has a type.',
+        type        => 'UINT',
+    },
+    # Will validate if field is not present, or if it is present and
+    # contains a C<UINT> value.
 
 The validate_if may also contain an arrayref of validation items.  So that
 multiple checks can be run.  They will be run in order.  validate_if will


### PR DESCRIPTION
Several POD updates; fixed broken C<...> tags, added another validate_if example, clarified 'required', etc.
